### PR TITLE
README - fix up markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@
 
 [comment]: <> (Table of contents generated with markdown-toc http://ecotrust-canada.github.io/markdown-toc/)
 <!-- TOC -->
-- [SSW Vertical Slice Architecture Template](#ssw-vertical-slice-architecture-template)
-    * [🤔 What is it?](#---what-is-it-)
-    * [✨ Features](#--features)
-    * [🎉 Getting Started](#---getting-started)
-    * [🎓 Learn More](#---learn-more)
-    * [🚀 Publishing Template](#---publishing-template)
-    * [🤝 Contributing](#---contributing)
+[SSW Vertical Slice Architecture Template](#ssw-vertical-slice-architecture-template)
+
+* [🤔 What is it?](#---what-is-it-)
+* [✨ Features](#--features)
+* [🎉 Getting Started](#---getting-started)
+* [🎓 Learn More](#---learn-more)
+* [🚀 Publishing Template](#---publishing-template)
+* [🤝 Contributing](#---contributing)
+
 <!-- TOC -->
 
 ## 🤔 What is it?
@@ -89,93 +91,84 @@ Read more on [SSW Rules to Better Vertical Slice Architecture](https://www.ssw.c
 ## 🎉 Getting Started
 
 ### Prerequisites
+
 - [Docker](https://www.docker.com/get-started/) / [Podman](https://podman.io/get-started)
 - [Dotnet 9](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
 
 ### Installing the Template
 
 1. Install the SSW CA template
-
-    ```bash
-    dotnet new install SSW.VerticalSliceArchitecture.Template
-    ```
+   ```bash
+   dotnet new install SSW.VerticalSliceArchitecture.Template
+   ```
 
 > NOTE: The template only needs to be installed once. Running this command again will update your version of the template.
 
 2. Create a new directory
-
-    ```bash
-    mkdir Sprout
-    cd Sprout
-    ```
+   ```bash
+   mkdir Sprout
+   cd Sprout
+   ```
 
 3. Create a new solution
-
-    ```bash
-    dotnet new ssw-vsa
-    ```
+   ```bash
+   dotnet new ssw-vsa
+   ```
 
 > NOTE: `name` is optional; if you don't specify it, the directory name will be used as the solution name and project namespaces.
 
 Alternatively, you can specify the `name` and `output` directory as follows:
 
-    ```bash
-    dotnet new ssw-vsa --name {{SolutionName}} --output .\
-    ```
+```bash
+dotnet new ssw-vsa --name {{SolutionName}} --output .\
+```
 
 ### Adding a Feature Slice
 
 To speed up development there is a `dotnet new` template to create a full Vertical Slice:
+
 - Creates a domain object in `Common/Domain/*`
 - Adds domain configuration in `Common/Persistence/*`
 - Creates Command & Query API endpoints in `Features/*`
 
 1. Add a new Feature
-
-    ```bash
-    cd src/WebApi/
-
-    dotnet new ssw-vsa-slice --feature Person --feature-plural People
-    ```
+   ```bash
+   cd src/WebApi/
+   dotnet new ssw-vsa-slice --feature Person --feature-plural People
+   ```
     
 `--feature` or `-f` where the value is the **singular** name of the feature.
 `--feature-plural` or `-fp` where the value is the **plural** name of the feature.
 
 2. Configure this Feature
-
-This project uses [strongly typed IDs](https://www.ssw.com.au/rules/do-you-use-strongly-typed-ids/), which require registration in the `VogenEfCoreConverters` class:
-
-    ```csharp
-    // Register the newly created Entity ID here
-    [EfCoreConverter<PersonId>]
-    internal sealed partial class VogenEfCoreConverters;
-    ```
+   This project uses [strongly typed IDs](https://www.ssw.com.au/rules/do-you-use-strongly-typed-ids/), which require registration in the `VogenEfCoreConverters` class:
+   ```csharp
+   // Register the newly created Entity ID here
+   [EfCoreConverter<PersonId>]
+   internal sealed partial class VogenEfCoreConverters;
+   ```
 
 3. Add a migration for the new Entity
-
-    ```bash
-    dotnet ef migrations add --project src/WebApi/WebApi.csproj --startup-project src/WebApi/WebApi.csproj --output-dir Common/Database/Migrations PersonTable 
-    ```
+   ```bash
+   dotnet ef migrations add --project src/WebApi/WebApi.csproj --startup-project src/WebApi/WebApi.csproj --output-dir Common/Database/Migrations PersonTable 
+   ```
 
 ### Running the Solution
 
 1. Change directory
-
    Windows:
-    ```ps
-    cd tools\AppHost\
-    ```
-
+   ```ps
+   cd tools\AppHost\
+   ```
    Mac/Linux:
-    ```bash
-    cd tools/AppHost/
-    ```
+   ```bash
+   cd tools/AppHost/
+   ```
 
 2. Run the solution
-
-    ```bash
-    dotnet run
-    ```
+   ```bash
+   dotnet run
+   ```
 
 > **NOTE:** The first time you run the solution, it may take a while to download the docker images, create the DB, and seed the data.
 


### PR DESCRIPTION
When I looked at the readme, I noticed that some of the code blocks were not rendering properly since they had different levels on indentation with the ordered list items they were under.

This pull request makes minor formatting improvements to the `README.md` file to enhance readability and consistency. The changes include the addition of blank lines for better spacing and the removal of unnecessary blank lines in code blocks and instructions.

Formatting improvements:

* Added blank lines between sections in the Table of Contents for better readability. (`README.md`: [README.mdL16-R24](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R24))
* Inserted blank lines before and after lists in the "Getting Started" and "Adding a Feature Slice" sections to improve spacing and clarity. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-L113) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129-L175)
* Removed unnecessary blank lines within code blocks and instructions to maintain a cleaner structure. (`README.md`: [README.mdR129-L175](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129-L175))