### PR TITLE
📝 Update README prerequisites and run command for .NET 10 + Aspire CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ Read more on [SSW Rules to Better Vertical Slice Architecture](https://www.ssw.c
 
 ### Prerequisites
 
-- [Docker](https://www.docker.com/get-started/) / [Podman](https://podman.io/get-started)
-- [Dotnet 9](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
+- [Docker](https://www.docker.com/get-started/) / [Podman](https://podman.io/get-started) / [OrbStack](https://orbstack.dev/)
+- [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)
+- [Aspire CLI](https://aspire.dev/get-started/install-cli/)
 
 ### Installing the Template
 
@@ -127,25 +128,15 @@ dotnet new ssw-vsa --name {{SolutionName}}
 
 ### Running the Solution
 
-1. Change directory<br />
-   Windows:
-   ```ps
-   cd tools\AppHost\
-   ```
-   Mac/Linux:
+1. Run the solution
    ```bash
-   cd tools/AppHost/
-   ```
-
-2. Run the solution
-   ```bash
-   dotnet run
+   aspire start
    ```
 
 > [!NOTE]
 > The first time you run the solution, it may take a while to download the docker images, create the DB, and seed the data.
 
-4. Open https://localhost:7255/swagger in your browser to see it running ️🏃‍♂️
+2. Open https://localhost:7255/swagger in your browser to see it running ️🏃‍♂️
 
 ## Adding Features
 


### PR DESCRIPTION
## Summary
- Modernise README Getting Started to match merged sister PR SSWConsulting/SSW.CleanArchitecture#606
- Add OrbStack, bump .NET 9 → 10 SDK, add Aspire CLI prereq, switch run command to `aspire start`
- Fix broken step numbering (1, 2, 4 → 1, 2)

## Changes
The template README told new users to install .NET 9 and run via `cd tools/AppHost` + `dotnet run`, which is no longer the recommended flow. This brings it in line with the current tooling and the project's own CLAUDE.md (`aspire start`).

## Test Plan
- [ ] Render README on GitHub, confirm Prerequisites lists OrbStack, .NET 10 SDK, Aspire CLI
- [ ] Confirm Running the Solution shows a single `aspire start` step and numbering reads 1, 2

## Implementation Plan
📋 The implementation plan for this PR is posted as a comment below — see `.claude/plans/feature-readme-aspire-prereqs.md` in the source tree for the authoritative version.