### PR TITLE
fix(deps): pin MessagePack 2.5.301 to clear NU1903 build warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,15 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Lets a central PackageVersion override a transitive dependency's resolved
+         version without adding a direct PackageReference (used to patch MessagePack below). -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.3.2" />
+    <!-- Transitive via Aspire.Hosting 13.3.2; pinned above the 2.5.192 it resolves
+         to in order to clear NU1903 (GHSA-hv8m-jj95-wg3x, high severity). -->
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="Aspire.Hosting.Azure.AppService" Version="13.3.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="13.3.2" />
     <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
@@ -13,7 +19,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <!-- 10.0.7 (not 10.0.0) to satisfy Aspire.Hosting.AppHost 13.3.2's >= 10.0.7
+         requirement, now enforced by transitive pinning. Matches the EF Core 10.0.7 pins. -->
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.3.2" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.4.7" />


### PR DESCRIPTION
## Summary

- Clear the only build warnings (NU1903) by pinning transitive MessagePack to patched 2.5.301
- Bump Microsoft.Extensions.Hosting 10.0.0 → 10.0.7 (latent downgrade exposed by transitive pinning)

## Changes

The build emitted 2 × NU1903 (high severity) for MessagePack 2.5.192, pulled in transitively
via Aspire.Hosting 13.3.2. Enabling Central Package transitive pinning lets one PackageVersion
entry override it with the patched 2.5.301 across the solution. That same pinning made an
existing Microsoft.Extensions.Hosting downgrade (10.0.0 vs Aspire's >= 10.0.7) a hard error,
so it's bumped to 10.0.7 to match. `dotnet build` is now 0 warnings, 0 errors.

## Test Plan

- [ ] `dotnet build` → `0 Warning(s)  0 Error(s)`
- [ ] `dotnet list package --include-transitive | grep MessagePack` → resolves to 2.5.301

## Implementation Plan

📋 The implementation plan for this PR is posted as a comment below — see `.claude/plans/bug-fix-build-warnings.md` in the source tree for the authoritative version.