### PR TITLE
chore: bump template to 2026.06.12 and add bump-version skill

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: bump-version
+description: Bump the SSW.VerticalSliceArchitecture.Template NuGet package version to cut a new release. Use when the user says "bump the version", "cut a release", "release a new version", "publish a new package version", or similar for this template repo. Edits the version in VerticalSliceArchitecture.nuspec — which is what triggers the publish — but never pushes or opens a PR.
+author: Daniel Mackay
+---
+
+## What "bump the version" means in this repo
+
+This repo is a `dotnet new` template published to NuGet as `SSW.VerticalSliceArchitecture.Template`. The release is push-triggered, not tag-triggered.
+
+`.github/workflows/package.yml` runs only when a push to `main` changes `VerticalSliceArchitecture.nuspec`. When it does, it:
+
+1. Packs the template with `nuget pack`.
+2. Pushes the `.nupkg` to NuGet.org.
+3. Reads `<version>` from the nuspec and creates a matching git tag.
+4. Publishes a GitHub release on that tag with auto-generated notes.
+
+So the `<version>` value in `VerticalSliceArchitecture.nuspec` *is* the release. Changing it and merging to `main` ships a new package. Nothing else cuts a release.
+
+## Versioning scheme: CalVer
+
+Versions are calendar dates, `YYYY.MM.DD` (e.g. `2025.12.10`, `2026.06.12`). There is no SemVer major/minor/patch decision — the new version is simply today's date. Confirm with `git tag --sort=-v:refname | head` if you need to see recent releases.
+
+## Steps
+
+1. Read the current `<version>` from `VerticalSliceArchitecture.nuspec`.
+2. Compute today's date as `YYYY.MM.DD`. That is the new version.
+3. Guard against a same-day re-release: run `git tag` and check the date isn't already a tag. If it is, a release already shipped today — append a numeric suffix (`YYYY.MM.DD.1`) or ask the user how they want to disambiguate. Don't silently overwrite.
+4. Update `<version>` to the new value.
+5. Refresh `<releaseNotes>`: summarise what changed since the last release. Get the commit list with `git log --oneline <last-tag>..HEAD` and distil it into a short, human summary (one or two sentences). This is the NuGet page blurb — GitHub generates the full PR-list notes separately, so keep it terse.
+6. Run the `humanizer` skill over the release-notes prose before finishing (per the repo/global content-writing rule).
+
+## Guardrails
+
+- Don't push. Don't open a PR. Don't merge to `main`. Editing the nuspec on `main` is what triggers the publish, so that final step is the user's call — leave the change as a reviewable diff.
+- Only touch `VerticalSliceArchitecture.nuspec`. The package versions in `Directory.Packages.props` are unrelated to the template's release version.
+- Don't edit the workflow.
+
+## Verify
+
+The change is metadata only — no build or test impact. Re-read the nuspec diff to confirm the version and notes are right. CI runs `nuget pack` (which needs mono) on merge, so there's nothing useful to run locally.

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -19,15 +19,17 @@ So the `<version>` value in `VerticalSliceArchitecture.nuspec` *is* the release.
 
 ## Versioning scheme: CalVer
 
-Versions are calendar dates, `YYYY.MM.DD` (e.g. `2025.12.10`, `2026.06.12`). There is no SemVer major/minor/patch decision — the new version is simply today's date. Confirm with `git tag --sort=-v:refname | head` if you need to see recent releases.
+Versions are calendar dates, `YYYY.MM.DD` (e.g. `2025.12.10`, `2026.06.12`). There is no SemVer major/minor/patch decision — the new version is simply today's date.
+
+To find the latest published version, use `gh release view --json tagName -q .tagName` — that's authoritative. Don't trust `git tag --sort=-v:refname | head`: the repo has both `v`-prefixed and bare tags (`v2025.10.24` *and* `2025.12.10`), and the mixed namespace makes that sort return a stale tag above the real latest.
 
 ## Steps
 
 1. Read the current `<version>` from `VerticalSliceArchitecture.nuspec`.
 2. Compute today's date as `YYYY.MM.DD`. That is the new version.
-3. Guard against a same-day re-release: run `git tag` and check the date isn't already a tag. If it is, a release already shipped today — append a numeric suffix (`YYYY.MM.DD.1`) or ask the user how they want to disambiguate. Don't silently overwrite.
+3. Guard against a same-day re-release: run `git fetch --tags` first (release tags are created by CI on the remote, so a local-only `git tag` can miss one shipped earlier today), then check the date isn't already a tag. If it is, a release already shipped today — append a numeric suffix (`YYYY.MM.DD.1`) or ask the user how they want to disambiguate. Don't silently overwrite.
 4. Update `<version>` to the new value.
-5. Refresh `<releaseNotes>`: summarise what changed since the last release. Get the commit list with `git log --oneline <last-tag>..HEAD` and distil it into a short, human summary (one or two sentences). This is the NuGet page blurb — GitHub generates the full PR-list notes separately, so keep it terse.
+5. Refresh `<releaseNotes>`: summarise what changed since the last release. The `<version>` you read in step 1 (before bumping) is the previous release's tag, so use it as the changelog base: `git log --oneline <previous-version>..HEAD`. Distil that into a short, human summary (one or two sentences). This is the NuGet page blurb — GitHub generates the full PR-list notes separately, so keep it terse.
 6. Run the `humanizer` skill over the release-notes prose before finishing (per the repo/global content-writing rule).
 
 ## Guardrails

--- a/VerticalSliceArchitecture.nuspec
+++ b/VerticalSliceArchitecture.nuspec
@@ -3,7 +3,7 @@
   <metadata>
 
     <id>SSW.VerticalSliceArchitecture.Template</id>
-    <version>2025.12.10</version>
+    <version>2026.06.12</version>
     <title>Vertical Slice Architecture Template</title>
     <authors>SSW Consulting</authors>
     <description>Vertical Slice Architecture template using ASP.NET Core</description>
@@ -12,7 +12,8 @@
       This template is just one way to apply the Vertical Slice Architecture.
     </summary>
     <releaseNotes>
-      Updated to .NET 10.
+      Feature slices now use one folder per use case, and specifications are split into
+      per-aggregate factory methods. Upgraded to Aspire 13.4.3 with dependency updates.
     </releaseNotes>
     <readme>README.md</readme>
 


### PR DESCRIPTION
## Summary

- Bump the template package version to `2026.06.12` (CalVer) to cut a new release
- Add a committed `bump-version` skill that captures the push-triggered release flow

## Changes

Editing `<version>` in `VerticalSliceArchitecture.nuspec` is what triggers `package.yml` to pack, push to NuGet, tag, and publish a release — so this bump *is* the release. It covers the slice folder reorganisation, per-aggregate specification factory methods, and the Aspire 13.4.3 upgrade landed since `2025.12.10`.

The new `.claude/skills/bump-version/SKILL.md` documents that mechanism plus the CalVer scheme so future bumps are one command, with guardrails against unreliable tag lookups (the repo's mixed `v`-prefixed and bare tags break `git tag --sort`) and same-day version collisions.

## Test Plan

- [ ] Confirm `<version>` reads `2026.06.12` in `VerticalSliceArchitecture.nuspec`
- [ ] On merge to `main`, the Package workflow runs → new NuGet version published + GitHub release created
- [ ] `bump-version` skill frontmatter parses and the skill triggers on "bump the version"

## Implementation Plan

📋 The implementation plan for this PR is posted as a comment below — see `.claude/plans/feature-bump-version-2026-06-12.md` in the source tree for the authoritative version.