### PR TITLE
feat(apphost): group Aspire containers under one "SSW.VSA" project in Docker UIs

### DIFF
--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "tools/AppHost/AppHost.csproj"
+  }
+}

--- a/tools/AppHost/AppHost.cs
+++ b/tools/AppHost/AppHost.cs
@@ -28,7 +28,7 @@ var sqlServer = builder
         // Use SQL Server 2022 as the default of SQL Server 2025 doesn't work on Linux/MacOS
         container.WithImage("mssql/server:2022-latest");
 
-        // Group under one "SSW.VSA" project in Docker Desktop / OrbStack (cosmetic only)
+        // Group under one "SSW-VSA" project in Docker Desktop / OrbStack (cosmetic only)
         container.InDockerProject();
 
         // If desired, set SQL Server Port to a constant value

--- a/tools/AppHost/AppHost.cs
+++ b/tools/AppHost/AppHost.cs
@@ -28,6 +28,9 @@ var sqlServer = builder
         // Use SQL Server 2022 as the default of SQL Server 2025 doesn't work on Linux/MacOS
         container.WithImage("mssql/server:2022-latest");
 
+        // Group under one "SSW.VSA" project in Docker Desktop / OrbStack (cosmetic only)
+        container.InDockerProject();
+
         // If desired, set SQL Server Port to a constant value
         //container.WithHostPort(1800);
     });

--- a/tools/AppHost/DockerComposeGrouping.cs
+++ b/tools/AppHost/DockerComposeGrouping.cs
@@ -1,0 +1,22 @@
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Groups Aspire-managed containers under one Docker Compose "project" in Docker Desktop / OrbStack.
+/// <c>aspire run</c> uses Aspire's own orchestrator rather than Compose, so its containers otherwise
+/// appear ungrouped at the top level of the Docker UI. Stamping the conventional Compose labels
+/// (<c>com.docker.compose.project</c> / <c>.service</c>) folds them into one named group. Cosmetic
+/// only — it does not change how Aspire runs the containers; the dashboard stays the source of truth.
+/// </summary>
+public static class DockerComposeGroupingExtensions
+{
+    // No docker-compose.yml in this repo, so this name can't clash with a real Compose project.
+    public const string DockerProject = "SSW.VSA";
+
+    public static IResourceBuilder<T> InDockerProject<T>(this IResourceBuilder<T> builder, string projectName = DockerProject)
+        where T : ContainerResource
+        => builder.WithContainerRuntimeArgs(
+            "--label", $"com.docker.compose.project={projectName}",
+            "--label", $"com.docker.compose.service={builder.Resource.Name}");
+}

--- a/tools/AppHost/DockerComposeGrouping.cs
+++ b/tools/AppHost/DockerComposeGrouping.cs
@@ -12,7 +12,9 @@ namespace Aspire.Hosting;
 public static class DockerComposeGroupingExtensions
 {
     // No docker-compose.yml in this repo, so this name can't clash with a real Compose project.
-    public const string DockerProject = "SSW.VSA";
+    // Kept dot-free ([a-z0-9][a-z0-9_-]* is the Compose project-name rule) so Docker UIs reliably
+    // fold the containers into this group — a "." can make the group be silently ignored.
+    public const string DockerProject = "SSW-VSA";
 
     public static IResourceBuilder<T> InDockerProject<T>(this IResourceBuilder<T> builder, string projectName = DockerProject)
         where T : ContainerResource


### PR DESCRIPTION
## Summary

- New `InDockerProject()` AppHost helper stamps the conventional Docker Compose labels (`com.docker.compose.project` / `.service`) so Aspire-managed containers fold into one named **`SSW-VSA`** group in OrbStack / Docker Desktop.
- Applied to the local `sql` container; helper is ready for any container a template consumer adds later.
- Adds `aspire.config.json` pinning the AppHost path so `aspire run` works from the repo root.

## Changes

`aspire run` uses Aspire's own orchestrator rather than Docker Compose, so its containers otherwise appear scattered at the top level of the Docker UI. Stamping the compose labels groups them under one project — like a normal Compose project — purely cosmetic local-dev DX, no runtime/app behaviour change. Ported from HubX #6565. No `docker-compose.yml` in the repo, so the `SSW-VSA` label can't clash with a real Compose project. The group name is kept dot-free (`[a-z0-9][a-z0-9_-]*` is the Compose project-name rule) so Docker UIs reliably fold the containers into the group.

## Test Plan

- [ ] `dotnet build tools/AppHost/AppHost.csproj` — clean build (green build proves the `where T : ContainerResource` constraint resolves against `SqlServerServerResource`).
- [ ] `aspire run`, then `docker inspect <sql-container>` and confirm `com.docker.compose.project=SSW-VSA` is present.
- [ ] In OrbStack / Docker Desktop, confirm the SQL container shows under a single `SSW-VSA` group rather than at the top level. Note: with `ContainerLifetime.Persistent`, an existing `sql` container from a prior run must be deleted once for the new labels to take effect.

## Implementation Plan

📋 The implementation plan for this PR is posted as a comment below — see `.claude/plans/feature-group-aspire-containers-docker-ui.md` in the source tree for the authoritative version.