### PR TITLE
⬆️ Bump Aspire to 13.4.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,12 +6,13 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.4.3" />
-    <!-- Transitive via Aspire.Hosting 13.4.3; pinned above the 2.5.192 it resolves
-         to in order to clear NU1903 (GHSA-hv8m-jj95-wg3x, high severity). -->
-    <PackageVersion Include="MessagePack" Version="2.5.301" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppService" Version="13.4.3" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="13.4.3" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.4.6" />
+    <!-- Transitive via Aspire.Hosting 13.4.6 (StreamJsonRpc 2.25.29 requires >= 2.5.302);
+         also clears NU1903 (GHSA-hv8m-jj95-wg3x, high severity) that the 2.5.192 it would
+         otherwise resolve to is subject to. -->
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppService" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="13.4.6" />
     <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
     <PackageVersion Include="FastEndpoints.Swagger" Version="7.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
@@ -19,11 +20,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <!-- Pinned to satisfy Aspire 13.4.3's transitive >= 10.0.8 requirement, now
+    <!-- Pinned to satisfy Aspire 13.4.6's transitive >= 10.0.8 requirement, now
          enforced by transitive pinning. Matches the EF Core 10.0.9 pins. -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.3" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.4.7" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="ErrorOr" Version="2.0.1" />
@@ -42,8 +43,8 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
   <ItemGroup Condition="$(IsAspireHost) == 'true'">
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.3" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.3" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
   </ItemGroup>
   <ItemGroup Condition="$(IsTestProject) == 'true'">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/tools/AppHost/AppHost.csproj
+++ b/tools/AppHost/AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary

- Patch-bump Aspire from **13.4.3 → 13.4.6** across all package pins and the AppHost MSBuild SDK reference.
- Move the transitive `MessagePack` pin `2.5.301 → 2.5.302` to satisfy Aspire 13.4.6's new floor (via StreamJsonRpc 2.25.29) while still clearing the NU1903 advisory.

## Changes

Aspire 13.4.6 is the latest stable release. Because the repo uses Central Package Management, all Aspire versions live in `Directory.Packages.props`; the one version CPM can't govern — the Aspire MSBuild SDK ref in `tools/AppHost/AppHost.csproj` — is edited directly. 13.4.6 raises the transitive MessagePack requirement to `2.5.302` (StreamJsonRpc 2.25.29), so the central pin moves up one patch; the pin comment is updated to reflect the new reason and confirm it still clears GHSA-hv8m-jj95-wg3x. No slice, AppHost-topology, or ServiceDefaults code changed.

## Test Plan

- [ ] `dotnet build` — clean (only the pre-existing `Microsoft.OpenApi` NU1903 warning, unrelated to this change).
- [ ] `dotnet test` on all suites — 48 pass (34 unit + 4 architecture + 10 integration via Testcontainers).
- [ ] `aspire start` — SQL Server, migrations, and WebApi all reach Healthy; `GET /api/heroes` returns seeded data and `/swagger` responds 200.
- [ ] Confirm no `13.4.3` references remain in `Directory.Packages.props` / `tools/AppHost/AppHost.csproj`.

## Implementation Plan

📋 The implementation plan for this PR is posted as a comment below — see `.claude/plans/feature-update-aspire-13-4-6.md` in the source tree for the authoritative version.