### PR TITLE
🔒 Pin Microsoft.OpenApi to 2.9.0 to clear NU1903 build failure

### DIFF
--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -50,12 +50,21 @@ against is a binary-compatibility bet, and neither restore nor build can prove i
 A member that moved or changed signature throws `MissingMethodException` or
 `TypeLoadException`, but only when that code actually runs.
 
-So when the bumped assembly is on a runtime path a compiled package calls into
-(OpenAPI document generation is the one this repo hit), a green build isn't
-enough. Exercise the path. For OpenAPI pins: `aspire start --isolated`, then
-`GET /swagger/v1/swagger.json` and confirm HTTP 200 with a valid document.
+So a green build isn't enough. You have to hit the endpoint that actually loads
+the bumped assembly, which means knowing which stack owns it. There's a trap here:
+this template runs two separate OpenAPI stacks. `Microsoft.OpenApi` belongs to
+`Microsoft.AspNetCore.OpenApi` (`AddOpenApi()` / `MapOpenApi()`, served at
+`/openapi/v1.json`). The `/swagger` UI and `/swagger/v1/swagger.json` come from
+FastEndpoints.Swagger, which uses NSwag and never touches `Microsoft.OpenApi`. A
+200 from `swagger.json` therefore tells you nothing about a `Microsoft.OpenApi`
+pin.
 
-Pins that only touch build-time or dashboard assemblies don't need this — the
-`MessagePack` pin, for instance, backs Aspire tooling and never reaches a
-request. Generated projects may wire OpenAPI or Aspire differently, so adapt the
-check to whatever surface actually loads the assembly.
+As shipped, the WebApi calls `AddOpenApi()` but never `MapOpenApi()`, so the
+`Microsoft.OpenApi` path isn't mapped and can't be exercised at all, so the pin
+here only clears the audit. Once something maps it (`aspire start --isolated`, then
+`GET /openapi/v1.json` expecting a valid document), that's the check to run.
+
+Pins that never reach a request don't need a runtime check. The `MessagePack`
+pin, for instance, backs Aspire tooling. Match the check to whatever surface
+really loads the assembly, and if nothing does, the pin is just satisfying the
+audit.

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -1,0 +1,61 @@
+---
+paths:
+  - "Directory.Packages.props"
+  - "Directory.Build.props"
+  - "**/*.props"
+---
+
+# Dependencies & NuGet Audit
+
+This is a template. `Directory.Packages.props` and `.claude/` both ship in the
+package, so pins and this guidance flow through to every generated project.
+
+## When a Release build suddenly fails with NU1903
+
+Release builds set `TreatWarningsAsErrors=true` (`Directory.Build.props`), and
+NuGetAudit raises `NU1903` for any package with a known-vuln advisory. When an
+advisory is published against a **transitive** dependency, the Release build —
+and CI on every open PR — breaks with no code change on your side.
+
+That break is environmental. Don't bisect the PR's own diff; the PR didn't cause
+it.
+
+### The fix
+
+Central transitive pinning is enabled (`CentralPackageTransitivePinningEnabled`),
+so add a `<PackageVersion>` for the affected transitive package in
+`Directory.Packages.props` at the first patched version (the GHSA lists its
+patched range), with a comment naming the parent package and the GHSA id. The
+`Microsoft.OpenApi` and `MessagePack` entries show the established shape.
+
+Pin the transitive package rather than bumping its parent or turning off the
+audit.
+
+The comment isn't decoration. Naming the parent package records *why* the pin
+exists, so a later package upgrade can revisit it: once the parent resolves a
+patched version on its own, the pin is dead weight and should go. Every transitive
+pin is a manual override of NuGet's resolution, so keep them minimal: pin only
+what an advisory or conflict actually forces, and scan these comments for pins to
+retire whenever you bump the parents.
+
+### Land it fast
+
+The failure sits on the shared baseline, not your branch, so every open PR stays
+red until the pin reaches `main`. Merge or cherry-pick it ahead of feature work.
+
+## Verify the pin at runtime when it sits on a request path
+
+Forcing a transitive package above the version a **compiled** consumer was built
+against is a binary-compatibility bet, and neither restore nor build can prove it.
+A member that moved or changed signature throws `MissingMethodException` or
+`TypeLoadException`, but only when that code actually runs.
+
+So when the bumped assembly is on a runtime path a compiled package calls into
+(OpenAPI document generation is the one this repo hit), a green build isn't
+enough. Exercise the path. For OpenAPI pins: `aspire start --isolated`, then
+`GET /swagger/v1/swagger.json` and confirm HTTP 200 with a valid document.
+
+Pins that only touch build-time or dashboard assemblies don't need this — the
+`MessagePack` pin, for instance, backs Aspire tooling and never reaches a
+request. Generated projects may wire OpenAPI or Aspire differently, so adapt the
+check to whatever surface actually loads the assembly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Detailed conventions are in `.claude/rules/` (auto-loaded by Claude Code when ma
 | `domain.md` | entities, aggregates, value objects, specs, strongly typed IDs, domain events |
 | `database.md` | adding entities, migration commands, seeding |
 | `testing.md` | unit, integration, and architecture test projects |
+| `dependencies.md` | NuGet audit (NU1903) failures, transitive pinning, verifying pins |
 
 ## Running the App
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,9 @@
     <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
     <PackageVersion Include="FastEndpoints.Swagger" Version="7.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <!-- Transitive via Microsoft.AspNetCore.OpenApi 10.0.0; pinned above the 2.0.0 it
+         resolves to in order to clear NU1903 (GHSA-v5pm-xwqc-g5wc, high severity). -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- Pin `Microsoft.OpenApi` to `2.9.0` via central transitive pinning so `NuGetAudit` stops failing restore/build

## Changes

A newly published advisory, [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (high severity), covers `Microsoft.OpenApi` `>= 2.0.0-preview11, <= 2.7.4`. `Microsoft.AspNetCore.OpenApi` 10.0.0 pulls in `Microsoft.OpenApi` 2.0.0 transitively, so `NuGetAudit` raises `NU1903` and — because warnings are treated as errors — restore fails on every project. This broke the build on all open PRs, not just the branch where it first surfaced.

The repo already handles this exact case for MessagePack, so the fix reuses that pattern: `CentralPackageTransitivePinningEnabled` is on, so a single central `PackageVersion` forces the safe version everywhere without adding a direct `PackageReference`.

## Test Plan

- [ ] `dotnet restore` succeeds with no `NU1903`
- [ ] `dotnet build --configuration Release` succeeds (0 warnings, 0 errors)
- [ ] `dotnet list src/WebApi/WebApi.csproj package --include-transitive` shows `Microsoft.OpenApi` resolving to `2.9.0`, with `Microsoft.AspNetCore.OpenApi` still at `10.0.0`

## Implementation Plan

📋 The implementation plan for this PR is posted as a comment below — see `.claude/plans/bug-pin-microsoft-openapi-nu1903.md` in the source tree for the authoritative version.