### PR TITLE
chore(database): upgrade SQL Server to 2025 in Aspire and Testcontainers

### DIFF
--- a/tests/WebApi.IntegrationTests/Common/Infrastructure/Database/SqlServerContainer.cs
+++ b/tests/WebApi.IntegrationTests/Common/Infrastructure/Database/SqlServerContainer.cs
@@ -10,7 +10,7 @@ namespace SSW.VerticalSliceArchitecture.IntegrationTests.Common.Infrastructure.D
 public class SqlServerContainer : IAsyncDisposable
 {
     private readonly MsSqlContainer _container = new MsSqlBuilder()
-        .WithImage("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
+        .WithImage("mcr.microsoft.com/mssql/server:2025-latest")
         .WithName($"WebApi-IntegrationTests-{Guid.NewGuid()}")
         .WithPassword("Password123")
         .WithPortBinding(1433, true)

--- a/tools/AppHost/AppHost.cs
+++ b/tools/AppHost/AppHost.cs
@@ -25,8 +25,8 @@ var sqlServer = builder
         // Configure SQL Server to run locally as a container
         container.WithLifetime(ContainerLifetime.Persistent);
 
-        // Use SQL Server 2022 as the default of SQL Server 2025 doesn't work on Linux/MacOS
-        container.WithImage("mssql/server:2022-latest");
+        // SQL Server 2025. Runs locally on macOS via OrbStack (Docker Desktop on Apple Silicon may not work).
+        container.WithImage("mssql/server:2025-latest");
 
         // Group under one "SSW-VSA" project in Docker Desktop / OrbStack (cosmetic only)
         container.InDockerProject();


### PR DESCRIPTION
## Summary

- Upgrade the Aspire local SQL Server container and the integration-test Testcontainer from **2022** to **2025** (`2025-latest`).
- Refresh the stale AppHost comment — 2025 is GA and runs on macOS via OrbStack.

## Changes

The template pinned SQL Server 2022 with a comment claiming 2025 "doesn't work on Linux/MacOS". That's no longer true: 2025 is GA on `mcr.microsoft.com/mssql/server` and runs locally on macOS via OrbStack. Both the Aspire AppHost image and the Testcontainers image now target the floating `2025-latest` tag. No EF provider, connection-string, or migration changes were needed — `UseSqlServer` is unchanged.

## Test Plan

- [ ] `dotnet build` succeeds
- [ ] `dotnet test tests/WebApi.IntegrationTests/` passes (boots the 2025 testcontainer)
- [ ] `aspire start` — the `sql` (2025) container, `migrations`, and `api` all reach a healthy/completed state on the dashboard

## Implementation Plan

📋 The implementation plan for this PR is posted as a comment below — see `.claude/plans/feature-upgrade-sql-server-2025.md` in the source tree for the authoritative version.