### PR TITLE
docs(aspire): note that aspire wait false-fails on run-to-completion jobs

### DIFF
--- a/.claude/skills/aspire/references/resource-management.md
+++ b/.claude/skills/aspire/references/resource-management.md
@@ -16,6 +16,7 @@ Keep these points in mind:
 - Use `aspire wait` before a dependent action when readiness is the real blocker.
 - Add `--status` and `--timeout` when the ask calls for an explicit readiness condition rather than a generic wait.
 - Treat readiness as a resource-scoped concern; a missing ready signal is not automatically a reason to restart the whole AppHost.
+- `aspire wait` waits for a resource to become healthy. A run-to-completion job (a migration or seed project the app `WaitForCompletion`s) exits 0 and has no live health check, so `aspire wait <job>` can report "failed to start" even when it succeeded. Confirm those jobs with `aspire logs <job>` (look for the clean-exit line) or by watching the dependent resource reach healthy, rather than with `aspire wait`.
 
 ## Scenario: Fix Or Operate On One Resource Without Bouncing The Whole App
 


### PR DESCRIPTION
## Summary

- Document that `aspire wait <job>` can report "failed to start" for a run-to-completion job (migration/seed) that has already succeeded.

## Changes

While verifying an Aspire boot, `aspire wait migrations` printed a failure even though the migration job had run, seeded the DB, and exited cleanly — the dependent `api` resource was healthy, proving success. A finished job has no live health check, so waiting for "healthy" misreads its clean exit as a failure. This adds a bullet under the `aspire wait` scenario in the skill's resource-management reference so the next verification run knows to confirm such jobs via logs (or the dependent resource going healthy) rather than `aspire wait`.

## Test Plan

- [ ] Read `.claude/skills/aspire/references/resource-management.md` under "Wait For One Resource Before Touching It" — the new bullet reads clearly and matches the surrounding style.