### PR TITLE
fix(ci): repair ADR GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # allow manual triggering
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -27,7 +28,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-node@v6
       with:
-        node-version: "14"
+        node-version: "21"
 
     - name: Install Log4Brains
       run: npm install -g log4brains
@@ -38,8 +39,8 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v5
       with:
-        # Upload entire repository
-        path: './_site'
+        # log4brains writes the static ADR site here (not ./_site)
+        path: './.log4brains/out'
         
     - name: Deploy to GitHub Pages
       id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -481,3 +481,6 @@ $RECYCLE.BIN/
 .claude/plans/
 .claude/worktrees/
 *.lscache
+
+# Log4brains ADR static site build output
+.log4brains/


### PR DESCRIPTION
## Problem

The **Publish & Deploy ADR** workflow (`deploy.yml`) has failed on every run, and GitHub Pages was never actually enabled on this repo (the Pages API returned 404). So the ADR site — the same thing [SSW.CleanArchitecture publishes](https://sswconsulting.github.io/SSW.CleanArchitecture/) — was never live for VSA.

Two bugs vs the working CleanArchitecture setup:

| | Was | Now |
|---|---|---|
| Node version | `14` (log4brains needs 18+) | `21` |
| Artifact path | `./_site` (never produced) | `./.log4brains/out` |

## Changes

- Bump `setup-node` to `21` (matches CleanArchitecture)
- Point `upload-pages-artifact` at `./.log4brains/out` — where `log4brains build` actually writes the static site
- Add `workflow_dispatch` so the deploy can be run manually
- Ignore `.log4brains/` local build output

## Pages enablement

Pages has been enabled with **source = GitHub Actions** (`build_type: workflow`). Public URL once this merges and the workflow runs:

**https://sswconsulting.github.io/SSW.VerticalSliceArchitecture/**

## Verification

Ran `log4brains build --basePath /SSW.VerticalSliceArchitecture` locally — 5 ADRs render to `.log4brains/out/index.html`. The workflow only triggers on push to `main`, so it'll deploy on merge (or via the new manual trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)