### PR TITLE
fix(validation): enforce domain max lengths in request validators

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -9,7 +9,12 @@ Three test projects, three different jobs.
 
 ## Unit Tests — `tests/WebApi.UnitTests/`
 
-Domain logic only: entity invariants, value objects, factory rules. No EF, no mocks. Reference: `tests/WebApi.UnitTests/Features/Heroes/HeroTests.cs`.
+Anything that runs without infrastructure. No EF, no mocks.
+
+- **Domain logic** — entity invariants, value objects, factory rules. Reference: `tests/WebApi.UnitTests/Features/Heroes/HeroTests.cs`.
+- **Request validators** — construct the validator directly (`new CreateHeroRequestValidator().Validate(req)`) and assert on `IsValid` / `Errors`. No DI or test host is needed, provided the rules don't call `Resolve<T>()`. Reference: `tests/WebApi.UnitTests/Features/Heroes/CreateHeroRequestValidatorTests.cs`.
+
+Where a validator mirrors a domain limit, drive the test boundaries off the domain constant (`Hero.NameMaxLength`) rather than a literal, so the test follows the limit when it moves.
 
 ## Integration Tests — `tests/WebApi.IntegrationTests/`
 

--- a/src/WebApi/Features/Heroes/CreateHero/CreateHeroRequestValidator.cs
+++ b/src/WebApi/Features/Heroes/CreateHero/CreateHeroRequestValidator.cs
@@ -1,3 +1,5 @@
+using SSW.VerticalSliceArchitecture.Common.Domain.Heroes;
+
 namespace SSW.VerticalSliceArchitecture.Features.Heroes.CreateHero;
 
 public class CreateHeroRequestValidator : Validator<CreateHeroRequest>
@@ -5,14 +7,20 @@ public class CreateHeroRequestValidator : Validator<CreateHeroRequest>
     public CreateHeroRequestValidator()
     {
         RuleFor(v => v.Name)
-            .NotEmpty();
+            .NotEmpty()
+            .MaximumLength(Hero.NameMaxLength);
 
         RuleFor(v => v.Alias)
-            .NotEmpty();
+            .NotEmpty()
+            .MaximumLength(Hero.AliasMaxLength);
 
         RuleForEach(v => v.Powers)
             .ChildRules(power =>
             {
+                power.RuleFor(p => p.Name)
+                    .NotEmpty()
+                    .MaximumLength(Power.NameMaxLength);
+
                 power.RuleFor(p => p.PowerLevel)
                     .InclusiveBetween(1, 10);
             });

--- a/src/WebApi/Features/Heroes/CreateHero/CreateHeroRequestValidator.cs
+++ b/src/WebApi/Features/Heroes/CreateHero/CreateHeroRequestValidator.cs
@@ -14,6 +14,11 @@ public class CreateHeroRequestValidator : Validator<CreateHeroRequest>
             .NotEmpty()
             .MaximumLength(Hero.AliasMaxLength);
 
+        // RuleForEach silently passes over a null collection, and the endpoint enumerates
+        // Powers unconditionally, so without this a body omitting "powers" is a 500 not a 400.
+        RuleFor(v => v.Powers)
+            .NotNull();
+
         RuleForEach(v => v.Powers)
             .ChildRules(power =>
             {

--- a/src/WebApi/Features/Heroes/UpdateHero/UpdateHeroRequestValidator.cs
+++ b/src/WebApi/Features/Heroes/UpdateHero/UpdateHeroRequestValidator.cs
@@ -1,3 +1,5 @@
+using SSW.VerticalSliceArchitecture.Common.Domain.Heroes;
+
 namespace SSW.VerticalSliceArchitecture.Features.Heroes.UpdateHero;
 
 public class UpdateHeroRequestValidator : Validator<UpdateHeroRequest>
@@ -8,9 +10,22 @@ public class UpdateHeroRequestValidator : Validator<UpdateHeroRequest>
             .NotEmpty();
 
         RuleFor(v => v.Name)
-            .NotEmpty();
+            .NotEmpty()
+            .MaximumLength(Hero.NameMaxLength);
 
         RuleFor(v => v.Alias)
-            .NotEmpty();
+            .NotEmpty()
+            .MaximumLength(Hero.AliasMaxLength);
+
+        RuleForEach(v => v.Powers)
+            .ChildRules(power =>
+            {
+                power.RuleFor(p => p.Name)
+                    .NotEmpty()
+                    .MaximumLength(Power.NameMaxLength);
+
+                power.RuleFor(p => p.PowerLevel)
+                    .InclusiveBetween(1, 10);
+            });
     }
 }

--- a/src/WebApi/Features/Heroes/UpdateHero/UpdateHeroRequestValidator.cs
+++ b/src/WebApi/Features/Heroes/UpdateHero/UpdateHeroRequestValidator.cs
@@ -17,6 +17,11 @@ public class UpdateHeroRequestValidator : Validator<UpdateHeroRequest>
             .NotEmpty()
             .MaximumLength(Hero.AliasMaxLength);
 
+        // RuleForEach silently passes over a null collection, and the endpoint enumerates
+        // Powers unconditionally, so without this a body omitting "powers" is a 500 not a 400.
+        RuleFor(v => v.Powers)
+            .NotNull();
+
         RuleForEach(v => v.Powers)
             .ChildRules(power =>
             {

--- a/src/WebApi/Features/Teams/CreateTeam/CreateTeamRequestValidator.cs
+++ b/src/WebApi/Features/Teams/CreateTeam/CreateTeamRequestValidator.cs
@@ -1,3 +1,5 @@
+using SSW.VerticalSliceArchitecture.Common.Domain.Teams;
+
 namespace SSW.VerticalSliceArchitecture.Features.Teams.CreateTeam;
 
 public class CreateTeamRequestValidator : Validator<CreateTeamRequest>
@@ -5,6 +7,7 @@ public class CreateTeamRequestValidator : Validator<CreateTeamRequest>
     public CreateTeamRequestValidator()
     {
         RuleFor(v => v.Name)
-            .NotEmpty();
+            .NotEmpty()
+            .MaximumLength(Team.NameMaxLength);
     }
 }

--- a/src/WebApi/Features/Teams/ExecuteMission/ExecuteMissionRequestValidator.cs
+++ b/src/WebApi/Features/Teams/ExecuteMission/ExecuteMissionRequestValidator.cs
@@ -1,3 +1,5 @@
+using SSW.VerticalSliceArchitecture.Common.Domain.Teams;
+
 namespace SSW.VerticalSliceArchitecture.Features.Teams.ExecuteMission;
 
 public class ExecuteMissionRequestValidator : Validator<ExecuteMissionRequest>
@@ -8,6 +10,7 @@ public class ExecuteMissionRequestValidator : Validator<ExecuteMissionRequest>
             .NotEmpty();
 
         RuleFor(v => v.Description)
-            .NotEmpty();
+            .NotEmpty()
+            .MaximumLength(Mission.DescriptionMaxLength);
     }
 }

--- a/tests/WebApi.UnitTests/Features/Heroes/CreateHeroRequestValidatorTests.cs
+++ b/tests/WebApi.UnitTests/Features/Heroes/CreateHeroRequestValidatorTests.cs
@@ -1,0 +1,106 @@
+using SSW.VerticalSliceArchitecture.Common.Domain.Heroes;
+using SSW.VerticalSliceArchitecture.Features.Heroes.CreateHero;
+
+namespace SSW.VerticalSliceArchitecture.UnitTests.Features.Heroes;
+
+public class CreateHeroRequestValidatorTests
+{
+    private readonly CreateHeroRequestValidator _validator = new();
+
+    // The domain setters throw on over-length input, so anything the validator lets through
+    // surfaces as a 500 instead of a 400. These boundaries are the contract between the two.
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(Hero.NameMaxLength, true)]
+    [InlineData(Hero.NameMaxLength + 1, false)]
+    public void Validator_WithNameOfLength_ShouldMatchDomainLimit(int length, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(name: new string('a', length));
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+
+        if (!expectedValid)
+        {
+            result.Errors.Should().Contain(e => e.PropertyName == nameof(CreateHeroRequest.Name));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(Hero.AliasMaxLength, true)]
+    [InlineData(Hero.AliasMaxLength + 1, false)]
+    public void Validator_WithAliasOfLength_ShouldMatchDomainLimit(int length, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(alias: new string('a', length));
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+
+        if (!expectedValid)
+        {
+            result.Errors.Should().Contain(e => e.PropertyName == nameof(CreateHeroRequest.Alias));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(Power.NameMaxLength, true)]
+    [InlineData(Power.NameMaxLength + 1, false)]
+    public void Validator_WithPowerNameOfLength_ShouldMatchDomainLimit(int length, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(powerName: new string('a', length));
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(10, true)]
+    [InlineData(11, false)]
+    public void Validator_WithPowerLevel_ShouldEnforceRange(int powerLevel, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(powerLevel: powerLevel);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+    }
+
+    [Fact]
+    public void Validator_WithValidRequest_ShouldPass()
+    {
+        // Act
+        var result = _validator.Validate(CreateRequest());
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    private static CreateHeroRequest CreateRequest(
+        string name = "Clark Kent",
+        string alias = "Superman",
+        string powerName = "Flight",
+        int powerLevel = 8) =>
+        new(name, alias, [new CreateHeroRequest.HeroPowerDto(powerName, powerLevel)]);
+}

--- a/tests/WebApi.UnitTests/Features/Heroes/CreateHeroRequestValidatorTests.cs
+++ b/tests/WebApi.UnitTests/Features/Heroes/CreateHeroRequestValidatorTests.cs
@@ -88,6 +88,20 @@ public class CreateHeroRequestValidatorTests
     }
 
     [Fact]
+    public void Validator_WithNullPowers_ShouldFail()
+    {
+        // Arrange — a body that omits "powers" deserializes to null, and the endpoint enumerates it
+        var request = new CreateHeroRequest("Clark Kent", "Superman", null!);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(CreateHeroRequest.Powers));
+    }
+
+    [Fact]
     public void Validator_WithValidRequest_ShouldPass()
     {
         // Act

--- a/tests/WebApi.UnitTests/Features/Heroes/UpdateHeroRequestValidatorTests.cs
+++ b/tests/WebApi.UnitTests/Features/Heroes/UpdateHeroRequestValidatorTests.cs
@@ -100,6 +100,20 @@ public class UpdateHeroRequestValidatorTests
     }
 
     [Fact]
+    public void Validator_WithNullPowers_ShouldFail()
+    {
+        // Arrange — a body that omits "powers" deserializes to null, and the endpoint enumerates it
+        var request = new UpdateHeroRequest("Clark Kent", "Superman", Guid.CreateVersion7(), null!);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateHeroRequest.Powers));
+    }
+
+    [Fact]
     public void Validator_WithValidRequest_ShouldPass()
     {
         // Act

--- a/tests/WebApi.UnitTests/Features/Heroes/UpdateHeroRequestValidatorTests.cs
+++ b/tests/WebApi.UnitTests/Features/Heroes/UpdateHeroRequestValidatorTests.cs
@@ -1,0 +1,123 @@
+using SSW.VerticalSliceArchitecture.Common.Domain.Heroes;
+using SSW.VerticalSliceArchitecture.Features.Heroes.UpdateHero;
+
+namespace SSW.VerticalSliceArchitecture.UnitTests.Features.Heroes;
+
+public class UpdateHeroRequestValidatorTests
+{
+    private readonly UpdateHeroRequestValidator _validator = new();
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(Hero.NameMaxLength, true)]
+    [InlineData(Hero.NameMaxLength + 1, false)]
+    public void Validator_WithNameOfLength_ShouldMatchDomainLimit(int length, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(name: new string('a', length));
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+
+        if (!expectedValid)
+        {
+            result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateHeroRequest.Name));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(Hero.AliasMaxLength, true)]
+    [InlineData(Hero.AliasMaxLength + 1, false)]
+    public void Validator_WithAliasOfLength_ShouldMatchDomainLimit(int length, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(alias: new string('a', length));
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+
+        if (!expectedValid)
+        {
+            result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateHeroRequest.Alias));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(Power.NameMaxLength, true)]
+    [InlineData(Power.NameMaxLength + 1, false)]
+    public void Validator_WithPowerNameOfLength_ShouldMatchDomainLimit(int length, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(powerName: new string('a', length));
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(10, true)]
+    [InlineData(11, false)]
+    public void Validator_WithPowerLevel_ShouldEnforceRange(int powerLevel, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(powerLevel: powerLevel);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+    }
+
+    [Fact]
+    public void Validator_WithEmptyHeroId_ShouldFail()
+    {
+        // Arrange
+        var request = CreateRequest(heroId: Guid.Empty);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateHeroRequest.HeroId));
+    }
+
+    [Fact]
+    public void Validator_WithValidRequest_ShouldPass()
+    {
+        // Act
+        var result = _validator.Validate(CreateRequest());
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    private static UpdateHeroRequest CreateRequest(
+        string name = "Clark Kent",
+        string alias = "Superman",
+        Guid? heroId = null,
+        string powerName = "Flight",
+        int powerLevel = 8) =>
+        new(
+            name,
+            alias,
+            heroId ?? Guid.CreateVersion7(),
+            [new UpdateHeroRequest.HeroPowerDto(powerName, powerLevel)]);
+}

--- a/tests/WebApi.UnitTests/Features/Teams/CreateTeamRequestValidatorTests.cs
+++ b/tests/WebApi.UnitTests/Features/Teams/CreateTeamRequestValidatorTests.cs
@@ -1,0 +1,41 @@
+using SSW.VerticalSliceArchitecture.Common.Domain.Teams;
+using SSW.VerticalSliceArchitecture.Features.Teams.CreateTeam;
+
+namespace SSW.VerticalSliceArchitecture.UnitTests.Features.Teams;
+
+public class CreateTeamRequestValidatorTests
+{
+    private readonly CreateTeamRequestValidator _validator = new();
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(Team.NameMaxLength, true)]
+    [InlineData(Team.NameMaxLength + 1, false)]
+    public void Validator_WithNameOfLength_ShouldMatchDomainLimit(int length, bool expectedValid)
+    {
+        // Arrange
+        var request = new CreateTeamRequest(new string('a', length));
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+
+        if (!expectedValid)
+        {
+            result.Errors.Should().Contain(e => e.PropertyName == nameof(CreateTeamRequest.Name));
+        }
+    }
+
+    [Fact]
+    public void Validator_WithValidRequest_ShouldPass()
+    {
+        // Act
+        var result = _validator.Validate(new CreateTeamRequest("Justice League"));
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/WebApi.UnitTests/Features/Teams/ExecuteMissionRequestValidatorTests.cs
+++ b/tests/WebApi.UnitTests/Features/Teams/ExecuteMissionRequestValidatorTests.cs
@@ -1,0 +1,60 @@
+using SSW.VerticalSliceArchitecture.Common.Domain.Teams;
+using SSW.VerticalSliceArchitecture.Features.Teams.ExecuteMission;
+
+namespace SSW.VerticalSliceArchitecture.UnitTests.Features.Teams;
+
+public class ExecuteMissionRequestValidatorTests
+{
+    private readonly ExecuteMissionRequestValidator _validator = new();
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(Mission.DescriptionMaxLength, true)]
+    [InlineData(Mission.DescriptionMaxLength + 1, false)]
+    public void Validator_WithDescriptionOfLength_ShouldMatchDomainLimit(int length, bool expectedValid)
+    {
+        // Arrange
+        var request = CreateRequest(description: new string('a', length));
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().Be(expectedValid);
+
+        if (!expectedValid)
+        {
+            result.Errors.Should().Contain(e => e.PropertyName == nameof(ExecuteMissionRequest.Description));
+        }
+    }
+
+    [Fact]
+    public void Validator_WithEmptyTeamId_ShouldFail()
+    {
+        // Arrange
+        var request = CreateRequest(teamId: Guid.Empty);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(ExecuteMissionRequest.TeamId));
+    }
+
+    [Fact]
+    public void Validator_WithValidRequest_ShouldPass()
+    {
+        // Act
+        var result = _validator.Validate(CreateRequest());
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    private static ExecuteMissionRequest CreateRequest(
+        Guid? teamId = null,
+        string description = "Save the city") =>
+        new(teamId ?? Guid.CreateVersion7(), description);
+}


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #226

⚠️ **Heads up: the issue's acceptance criteria are wrong, and this PR deliberately does not implement them.**

#226 asks for a *minimum* length of 31 characters on hero `Name` ("reject `Name` with length `<= 30`"). That would reject `"Clark Kent"`, breaking `CreateHeroCommandTests`, the Bogus `HeroFactory`, and the Swagger example on `CreateHeroSummary`. A minimum length on a person's name isn't a sensible rule. Full reasoning was [posted to the issue](https://github.com/SSWConsulting/SSW.VerticalSliceArchitecture/issues/226#issuecomment-5153769886) before any code was written — please push back there or here if you disagree.

The real gap is a **maximum** length, and it spans every slice rather than one field. The domain declares the limits and EF already binds to them; the validators were the only layer ignoring them:

- `Hero.cs:13` — `NameMaxLength` / `AliasMaxLength = 100`, enforced in the property setters via `ThrowIfGreaterThan`
- `HeroConfiguration.cs:13` — EF already uses those constants for `HasMaxLength`
- `grep MaximumLength src/WebApi/Features` — **zero hits**

So `POST /heroes` with a 101-character name sailed through FluentValidation, reached `Hero.Create`, and threw `ArgumentOutOfRangeException` from the setter — a **500 where a 400 belongs**.

> 2. What was changed?

Every request validator now enforces its string limits through the domain constant, never a literal, so a validator can't drift from the domain and the EF column.

| Validator | Rules added |
|---|---|
| `CreateHeroRequestValidator` | `Name`, `Alias`, `Powers[].Name` |
| `UpdateHeroRequestValidator` | `Name`, `Alias`, plus the whole `Powers` child-rules block |
| `CreateTeamRequestValidator` | `Name` |
| `ExecuteMissionRequestValidator` | `Description` |

`AddHeroToTeam`, `CompleteMission` and `GetTeam` are untouched — ID-only requests with nothing to bound.

`UpdateHero` is the one change that goes beyond adding a max length: it accepted `Powers` and validated none of it, while `CreateHero` validated power level. In a template repo, two near-identical slices disagreeing is exactly the thing people copy.

FluentValidation's default message already names the field and the limit (`'Name' must be 100 characters or fewer.`), so no hand-written `.WithMessage()` per rule — that would be five more places to drift.

A second instance of the same bug shape surfaced during review and is fixed here too: `RuleForEach` silently passes over a **null** collection, and both hero endpoints enumerate `req.Powers` unconditionally. `System.Text.Json` doesn't enforce non-nullable reference types unless `RespectNullableAnnotations` is set, and it isn't configured anywhere in this repo — so a body omitting `"powers"` bound `Powers` to null and threw `NullReferenceException`. Another 500 where a 400 belongs. Both hero validators now carry `RuleFor(v => v.Powers).NotNull()`.

Also included:

- **4 new unit test files, 48 tests** — each boundary (`0` empty, `1`, `limit`, `limit + 1`) per field, with the boundary driven off the domain constant rather than a hardcoded `100`, so the tests follow the limit when it moves. Plus a null-`Powers` case per hero validator.
- **`.claude/rules/testing.md`** — it described unit tests as "domain logic only", which would send validator tests to the integration project for no reason. Widened to cover request validators.

**Verified:** Debug and Release builds both clean (0 warnings — Release sets `TreatWarningsAsErrors`), `WebApi.UnitTests` 82/82, `WebApi.ArchitectureTests` 4/4, `WebApi.IntegrationTests` 10/10 against real SQL Server via Testcontainers. The length tests were confirmed **red before** the rules were added — 12 failures, exactly the over-limit boundaries — so they're proven to bite rather than passing vacuously.

> 3. Did you do pair or mob programming?

No — solo, written with Claude Code via `/do-work`.
