### PR TITLE
docs: add agent config and domain glossary

### DIFF
--- a/.claude/rules/domain.md
+++ b/.claude/rules/domain.md
@@ -43,7 +43,7 @@ public sealed class HeroSpec : SingleResultSpecification<Hero>
 
 ## Domain Events
 
-- Inherit from `DomainEvent`. Raise via `AddDomainEvent(...)` on the aggregate.
+- Declare as a `record` implementing `IEvent` (FastEndpoints). Raise via `AddDomainEvent(...)` on the aggregate. Reference: `PowerLevelUpdatedEvent.cs`.
 - Dispatched by `DispatchDomainEventsInterceptor` after `SaveChangesAsync()`. Handlers run in the same transaction.
 - If a handler can't complete, throw `EventualConsistencyException` so the middleware translates it for HTTP.
 - Example chain: `PowerLevelUpdatedEventHandler` recalculates team power when a hero's powers change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-A template for **.NET 10 + Vertical Slice Architecture + Aspire**. Each feature is a self-contained vertical slice under `src/WebApi/Features/`, shared domain types sit in `src/WebApi/Common/Domain/`, and infrastructure (EF Core, middleware, services) lives in `src/WebApi/Common/`.
+A template for **.NET 10 + Vertical Slice Architecture + Aspire**. Each use case is a self-contained vertical slice in its own folder under `src/WebApi/Features/{Feature}/`, shared domain types sit in `src/WebApi/Common/Domain/`, and infrastructure (EF Core, middleware, services) lives in `src/WebApi/Common/`. Terms are defined in `CONTEXT.md`.
 
 ## Technology Stack
 
@@ -44,3 +44,17 @@ Aspire provisions SQL Server (Docker/Podman), runs migrations and seeds via `too
 
 - **Auth** — add the auth scheme your project needs.
 - **Per-feature DI** — most slices don't need `IFeature.ConfigureServices()`. Add it only when a slice has its own services.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `SSWConsulting/VerticalSliceArchitecture`, driven with the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage labels, unrenamed. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,11 @@ Aspire provisions SQL Server (Docker/Podman), runs migrations and seeds via `too
 
 ### Issue tracker
 
-GitHub Issues on `SSWConsulting/VerticalSliceArchitecture`, driven with the `gh` CLI. See `docs/agents/issue-tracker.md`.
+GitHub Issues on `SSWConsulting/SSW.VerticalSliceArchitecture`, driven with the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
-The five canonical triage labels, unrenamed. See `docs/agents/triage-labels.md`.
+The five canonical triage labels, unrenamed — but only `wontfix` exists on the repo so far. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ GitHub Issues on `SSWConsulting/SSW.VerticalSliceArchitecture`, driven with the 
 
 ### Triage labels
 
-The five canonical triage labels, unrenamed — but only `wontfix` exists on the repo so far. See `docs/agents/triage-labels.md`.
+The five canonical triage labels, unrenamed. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,93 @@
+# SSW Vertical Slice Architecture
+
+A published .NET solution template. Two vocabularies live here and must not be mixed: the **template vocabulary**, which is what the repo is actually about, and the **sample domain**, which exists only to demonstrate the template and is deleted by consumers.
+
+## Template language
+
+**Template**:
+The packaged artifact consumers install with `dotnet new`, built from this repo by `VerticalSliceArchitecture.nuspec`. "The template" means the shipped thing; "the repo" means this working copy.
+_Avoid_: Boilerplate, starter kit, scaffold
+
+**Slice**:
+One use case, owning everything it needs from HTTP surface to persistence, living in its own folder under a Feature. `CreateHero` is a slice; so is `PowerLevelUpdated` — a slice may be triggered by a domain event rather than a request.
+_Avoid_: Handler, module, command (as a name for the whole use case)
+
+**Feature**:
+A group of slices over the same aggregate, sharing a route prefix. `Heroes` is a Feature; it is not itself a slice.
+_Avoid_: Module, area, domain (as a name for this grouping)
+
+**Group**:
+The route prefix a Feature's slices are registered under, so every endpoint in `Heroes` resolves beneath `/api/heroes`.
+_Avoid_: Route group, prefix class
+
+**Endpoint**:
+The HTTP entry point of a slice — one route, one request shape, one response shape.
+_Avoid_: Controller, action, handler
+
+**Aggregate**:
+A cluster of entities and value objects saved and validated as one unit, entered only through its root. `Team` is an aggregate; `Mission` is inside it and cannot be created independently.
+_Avoid_: Root object, entity graph
+
+**Entity**:
+A domain object with identity and a lifecycle, whose invariants are enforced on the object itself rather than by callers.
+_Avoid_: Model, record, POCO
+
+**Value Object**:
+A domain object with no identity, compared by its values and immutable once constructed. `Power` is one.
+_Avoid_: DTO, struct
+
+**Specification**:
+A named, reusable query for an aggregate, defined as a factory method on that aggregate's spec class so every query for it lives in one place.
+_Avoid_: Repository, query object, filter
+
+**Strongly Typed ID**:
+An identifier wrapped in its own type, so a `HeroId` can never be passed where a `TeamId` is expected.
+_Avoid_: Wrapped ID, ID struct, primitive ID
+
+**Domain Event**:
+A record of something that has already happened inside an aggregate, raised by the aggregate and handled after the change is saved.
+_Avoid_: Message, notification, integration event
+
+**Eventual Consistency Failure**:
+A failure in a domain event handler, after the originating aggregate has already been saved. The write stands; the follow-on work did not.
+_Avoid_: Side effect error, post-save error
+
+**Migration Service**:
+The startup worker that brings the database to the current schema and seeds it before the API serves traffic.
+_Avoid_: Seeder, migrator, DB init
+
+## Sample domain language
+
+Demonstration only. Consumers delete this domain; nothing in it is a claim about how a real system should model superheroes.
+
+**Hero**:
+A character with an alias and a set of powers, who may belong to one Team at a time.
+_Avoid_: Character, user, member
+
+**Alias**:
+The public-facing name a Hero is known by, distinct from their name.
+_Avoid_: Nickname, callsign, handle
+
+**Power**:
+A named ability held by a Hero, carrying its own strength rating.
+_Avoid_: Ability, skill, trait
+
+**Power Level**:
+A strength rating. On a Power it is that ability's rating; on a Hero it is the sum across their powers.
+_Avoid_: Strength, score, rating
+
+**Total Power Level**:
+The combined Power Level of every Hero currently on a Team.
+_Avoid_: Team power, strength
+
+**Team**:
+A group of Heroes that takes on Missions, and which is either Available or already on one.
+_Avoid_: Squad, group, roster
+
+**Mission**:
+A described piece of work a Team takes on, either in progress or complete. A Mission belongs to exactly one Team and only that Team can start or complete it.
+_Avoid_: Task, job, quest
+
+**Available**:
+The state of a Team with no Mission in progress — the only state from which a Mission can be started.
+_Avoid_: Idle, free, ready

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,41 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the glossary / ubiquitous language.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. ADRs are managed by [Log4brains](https://github.com/thomvaill/log4brains) and named `YYYYMMDD-<slug>.md`; `docs/adr/index.md` lists them and `docs/adr/template.md` is the starting point for a new one.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a **single-context** repo — one glossary, one ADR directory, both at the root:
+
+```
+/
+├── CONTEXT.md                                          ← created lazily by /domain-modeling
+├── docs/adr/
+│   ├── index.md
+│   ├── template.md
+│   ├── 20251018-api-use-fastendpoints-instead-of-minimal-apis.md
+│   └── 20260612-use-aggregate-specification-classes-with-factory-methods.md
+└── src/
+    ├── WebApi/
+    └── ServiceDefaults/
+```
+
+Vertical slices under `src/WebApi/Features/` are feature folders, not bounded contexts — they don't get their own `CONTEXT.md` or `docs/adr/`. If this repo ever splits into genuinely separate contexts, switch to a root `CONTEXT-MAP.md` pointing at per-context `CONTEXT.md` files.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR 20251018 (FastEndpoints instead of minimal APIs) — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -9,6 +9,8 @@ How the engineering skills should consume this repo's domain documentation when 
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
 
+Those skills ship outside this repo — `.claude/skills/` here only holds `aspire` and `bump-version`. If a referenced skill isn't installed, do the reading described above by hand and move on rather than trying to invoke it.
+
 ## File structure
 
 This is a **single-context** repo — one glossary, one ADR directory, both at the root:
@@ -20,7 +22,8 @@ This is a **single-context** repo — one glossary, one ADR directory, both at t
 │   ├── index.md
 │   ├── template.md
 │   ├── 20251018-api-use-fastendpoints-instead-of-minimal-apis.md
-│   └── 20260612-use-aggregate-specification-classes-with-factory-methods.md
+│   ├── 20260612-use-aggregate-specification-classes-with-factory-methods.md
+│   └── ...                                             ← run `ls docs/adr/` for the full set
 └── src/
     ├── WebApi/
     └── ServiceDefaults/

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -5,7 +5,7 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **Read an issue**: `gh issue view <number> --comments` for a human-readable dump. `--comments` and `--json` are mutually exclusive (passing both silently drops `--comments`), so when you need to filter with `jq`, use `gh issue view <number> --json number,title,body,labels,comments --jq '...'` instead.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
@@ -20,7 +20,7 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **List external PRs for triage**: `gh pr list --json` has no `authorAssociation` field, so go through the REST API — `gh api 'repos/{owner}/{repo}/pulls?state=open' --jq '.[] | select(.author_association as $a | ["CONTRIBUTOR","FIRST_TIME_CONTRIBUTOR","NONE"] | index($a)) | {number, title, user: .user.login, author_association}'` — keeping only `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
 - **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -14,15 +14,15 @@ When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the 
 
 Edit the right-hand column to match whatever vocabulary you actually use.
 
-## These labels are not all created yet
+## Recreating the labels
 
-Of the five, only `wontfix` currently exists on the repo — `gh issue edit --add-label needs-triage` fails with `'needs-triage' not found` until the label is created. Check with `gh label list`, and create anything missing before the first triage run:
+All five exist on the repo. `gh issue edit --add-label` fails with `'<name>' not found` against a label that doesn't, so if one is ever deleted, recreate it with the definition it was made from:
 
 ```bash
-gh label create needs-triage   --description "Maintainer needs to evaluate this issue" --color FBCA04
-gh label create needs-info     --description "Waiting on reporter for more information" --color D876E3
+gh label create needs-triage    --description "Maintainer needs to evaluate this issue" --color FBCA04
+gh label create needs-info      --description "Waiting on reporter for more information" --color D876E3
 gh label create ready-for-agent --description "Fully specified, ready for an AFK agent" --color 0E8A16
 gh label create ready-for-human --description "Requires human implementation"           --color 1D76DB
 ```
 
-`gh label create` errors if the label already exists; add `--force` to make it idempotent.
+`gh label create` errors if the label already exists; add `--force` to overwrite instead.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -13,3 +13,16 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
+
+## These labels are not all created yet
+
+Of the five, only `wontfix` currently exists on the repo — `gh issue edit --add-label needs-triage` fails with `'needs-triage' not found` until the label is created. Check with `gh label list`, and create anything missing before the first triage run:
+
+```bash
+gh label create needs-triage   --description "Maintainer needs to evaluate this issue" --color FBCA04
+gh label create needs-info     --description "Waiting on reporter for more information" --color D876E3
+gh label create ready-for-agent --description "Fully specified, ready for an AFK agent" --color 0E8A16
+gh label create ready-for-human --description "Requires human implementation"           --color 1D76DB
+```
+
+`gh label create` errors if the label already exists; add `--force` to make it idempotent.


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Ran `/setup-matt-pocock-skills` and `/domain-modeling` against this repo. The first needs per-repo config that didn't exist yet; the second surfaced two places where the docs disagreed with the code.

> 2. What was changed?

**New — `docs/agents/`**, the per-repo config the engineering skills read:

- `issue-tracker.md` — GitHub Issues via the `gh` CLI (PRs-as-a-request-surface flag left off)
- `triage-labels.md` — the five canonical triage labels, unrenamed
- `domain.md` — consumer rules for the domain docs, tuned to this repo's Log4brains `docs/adr/`

**New — `CONTEXT.md`**, a root glossary in two deliberately separate halves. *Template language* (Slice, Feature, Group, Endpoint, Aggregate, Specification, Strongly Typed ID, Domain Event, Eventual Consistency Failure, Migration Service) is what issues and PRs here actually argue about. *Sample domain language* (Hero, Power, Team, Mission…) is flagged demo-only, since consumers delete it.

**Fixed — two contradictions the glossary exposed:**

- `AGENTS.md` said "each feature is a self-contained vertical slice", but ADR 20260515 defines the slice as the **use-case** folder and `architecture.md` names `Features/Heroes/CreateHero/` the reference slice. The ADR wins; `AGENTS.md` now matches it.
- `.claude/rules/domain.md` told authors to inherit a `DomainEvent` base type. No such type exists — domain events are `record`s implementing FastEndpoints' `IEvent`, as `AggregateRoot.AddDomainEvent(IEvent)` and `PowerLevelUpdatedEvent` both show.

`AGENTS.md` also gains an `## Agent skills` section pointing at the three new files. `CLAUDE.md` is a symlink to it, so it picks the change up for free.

> 3. Did you do pair or mob programming?

No — solo, with Claude Code.

## How to review

Docs only; nothing compiles differently, so no build or test run is claimed.

- [ ] `CONTEXT.md` — is the Slice/Feature split the vocabulary you want enforced from here on?
- [ ] Confirm the `AGENTS.md` wording now agrees with `docs/adr/20260515-vertical-slices-use-a-folder-per-slice.md`
- [ ] Spot-check the `IEvent` claim against `src/WebApi/Common/Domain/Heroes/PowerLevelUpdatedEvent.cs`