### PR TITLE
docs(migrations): require --force when removing a migration

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -23,6 +23,17 @@ dotnet ef migrations add MigrationName \
   --output-dir Common/Persistence/Migrations
 ```
 
+Nothing needs to be running to scaffold a migration. Removing one is the opposite — it always
+needs `--force`, because Aspire only gives the connection string to the `migrations` and `api`
+resources, so EF can't check whether the migration was applied:
+
+```bash
+dotnet ef migrations remove \
+  --project src/WebApi/WebApi.csproj \
+  --startup-project src/WebApi/WebApi.csproj \
+  --force
+```
+
 Migrations apply automatically in dev, so you don't need to run `database update` by hand. The
 AppHost declares a `migrations` resource (`AddEFMigrations` + `RunDatabaseUpdateOnStart`) that runs
 `dotnet ef database update` before the API starts. That resource shells out to the `dotnet-ef` tool,

--- a/.claude/skills/add-entity/references/persistence.md
+++ b/.claude/skills/add-entity/references/persistence.md
@@ -140,7 +140,7 @@ Read the generated file before moving on. Things that show up here:
 | Column is `nvarchar(max)` | `HasMaxLength` missing from the configuration |
 | Unexpected drops on other tables | The model snapshot was out of date; check nothing else was edited |
 
-To undo an unwanted migration, `dotnet ef migrations remove` before it's been applied anywhere. Never edit an already-applied migration — roll forward instead.
+To undo an unwanted migration, `dotnet ef migrations remove --project src/WebApi/WebApi.csproj --startup-project src/WebApi/WebApi.csproj --force`, before it's been applied anywhere. `--force` is always needed: Aspire hands the connection string to the `migrations` resource, not to your shell, so EF can't check whether the migration was applied and stops with `The ConnectionString property has not been initialized`. Never edit an already-applied migration — roll forward instead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ live in `src/WebApi`, so every command below targets that one project.
 dotnet ef migrations add YourMigrationName --project src/WebApi/WebApi.csproj --startup-project src/WebApi/WebApi.csproj --output-dir Common/Persistence/Migrations
 ```
 
+Nothing needs to be running for this — no database, no AppHost. Scaffolding a migration only
+needs the model.
+
 #### Applying a Migration
 
 Locally, .NET Aspire handles this for you — just start the project. The `migrations` resource
@@ -214,15 +217,21 @@ On Azure this is a deployment step rather than something the app does to itself 
 #### Removing a Migration
 
 ```bash
-dotnet ef migrations remove --project src/WebApi/WebApi.csproj --startup-project src/WebApi/WebApi.csproj
+dotnet ef migrations remove --project src/WebApi/WebApi.csproj --startup-project src/WebApi/WebApi.csproj --force
 ```
 
-No `--force` and no `aspire exec`: the app no longer has to be running for this. Removing a
-migration that has already been applied to your local database still fails, which is EF Core
-protecting you rather than a quirk of the orchestration. Either drop the local database first
-(the **Drop Database** command on the `AppDb` resource in the dashboard) or roll forward with a
-new migration that undoes the change — rolling forward is the safer habit once a migration has
-left your machine.
+`--force` is always required here, and not because anything needs to be running. Aspire injects
+the connection string into the `migrations` and `api` resources at runtime, so a `dotnet ef` you
+run yourself never gets one. EF can't reach the database to check whether the migration has been
+applied, and refuses to guess — without `--force` it stops at
+`The ConnectionString property has not been initialized`.
+
+`--force` skips that check, so mind what the check was for. If you've started the app since
+adding the migration, the `migrations` resource has already applied it, and deleting the files
+leaves the database ahead of the model. Recover by dropping the local database — the **Drop
+Database** command on the `AppDb` resource, from the dashboard or via
+`aspire resource AppDb drop-database` — or by rolling forward with a new migration that undoes
+the change. Rolling forward is the safer habit once a migration has left your machine.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
Closes #289

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #289 — the README's EF migration commands. Most of the issue was already fixed by #300, but that rewrite introduced an untested claim: it dropped `--force` from the remove command, reasoning that moving to `AddEFMigrations` meant the app no longer had to be running. Running the documented commands shows the claim is wrong, and wrong in a way that fails on first use.

> 2. What was changed?

✏️ Aspire injects the connection string into the `migrations` and `api` resources at runtime, so a `dotnet ef` you run from a shell never gets one. EF can't check whether the migration was applied and stops at `The ConnectionString property has not been initialized` — identically whether the app is running or not. `--force` is therefore always required.

- `README.md` — `--force` restored to the remove command; the rationale rewritten to the real cause; the consequence spelled out (if you've started the app, the `migrations` resource has already applied the migration, so removing it leaves the database ahead of the model); `aspire resource AppDb drop-database` named alongside the dashboard command as the recovery path; the add command noted as needing nothing running; the last `aspire exec` mention removed, since that command never existed in the pinned CLI
- `.claude/rules/database.md` and `.claude/skills/add-entity/references/persistence.md` — same correction, so the three docs agree

Verified by running every documented command, cold and with Aspire up:

| Case | Result |
|---|---|
| `add`, nothing running | ✅ files land in `Common/Persistence/Migrations` |
| `remove`, nothing running, no `--force` | ❌ `The ConnectionString property has not been initialized.` |
| `remove`, Aspire up and the migration applied by the `migrations` resource, no `--force` | ❌ identical error |
| `remove --force` | ✅ removes, warning that it couldn't check applied state |
| `aspire resource AppDb drop-database` | ✅ |

Docs only — no build or test run, nothing outside markdown changes. Reviewers can re-run the two commands from the README section; `git status` should be clean afterwards apart from the model snapshot, which is the separate staleness tracked in #293.

> 3. Did you do pair or mob programming?

✏️ Solo, with Claude Code.

🤖